### PR TITLE
Fix undefined constant causing video processor crash

### DIFF
--- a/src/hooks/useVideoProcessor.js
+++ b/src/hooks/useVideoProcessor.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import {
-  FACEMESH_TESSELATION,
+  FACEMESH_TESSELLATION,
   FACEMESH_FACE_OVAL,
   FACEMESH_LEFT_EYE,
   FACEMESH_LEFT_EYEBROW,
@@ -54,7 +54,7 @@ const useVideoProcessor = (webcamRef, canvasRef, faceLandmarkerRef) => {
                 });
               };
 
-              drawConnections(FACEMESH_TESSELATION, "rgba(0,255,0,0.5)");
+              drawConnections(FACEMESH_TESSELLATION, "rgba(0,255,0,0.5)");
               drawConnections(FACEMESH_RIGHT_EYE, "rgba(0,255,255,0.8)", 2);
               drawConnections(FACEMESH_RIGHT_EYEBROW, "rgba(0,255,255,0.8)", 2);
               drawConnections(FACEMESH_LEFT_EYE, "rgba(0,255,255,0.8)", 2);


### PR DESCRIPTION
## Summary
- correct constant name for facial mesh tessellation import
- use the right constant when drawing connections

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8fdbdfa8832e8b2ef39120ae0c18